### PR TITLE
Better target leading and target determination

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -103,7 +103,7 @@ namespace TargetLeading
                     continue;
                 }
 
-                Vector3D interceptPoint = CalculateProjectileIntercept(
+                Vector3D interceptPoint = turretLoc + CalculateProjectileIntercept(
                     projectileSpeed,
                     turret.CubeGrid.Physics.LinearVelocity,
                     turretLoc,


### PR DESCRIPTION
* Uses a better algorithm that compensates for target velocity. Acceleration is neglected due to the uselessness of solving a quartic.

* Checks if any of a grid's owners are hostile to determine if a firing solution should be computed. This prevents users from being able to "ghost ride" and render enemy's assisted targeting useless.

* Fixed your silly single line return statements <3

* Fixed variable names to conform to standard

* Made more concise method names

NOTE: Lead will be projected something like 10x the distance to the target point. This is to prevent GPS signals from overlapping as often.